### PR TITLE
If link element is changed to button the keyup clickhandler is firing.

### DIFF
--- a/src/read-smore.js
+++ b/src/read-smore.js
@@ -201,7 +201,7 @@ function ReadSmore(element, options) {
       handleToggle(event, idx, isInlineLink)
     )
     link.addEventListener('keyup', (event) => {
-      if (event.keyCode === 13) handleToggle(event, idx, isInlineLink)
+      if (event.keyCode === 13 && options.linkElement === 'a') handleToggle(event, idx, isInlineLink)
     })
   }
 


### PR DESCRIPTION
At the moment, if linkElement is changed to a button the keyup handler is firing, which causes the text to expand and collapse without staying open. 