### PR TITLE
Fix: remove duplicate id when called mote than one time

### DIFF
--- a/src/read-smore.js
+++ b/src/read-smore.js
@@ -163,7 +163,7 @@ function ReadSmore(element, options) {
     const isInlineLink = isInline(element[idx])
     const linkWrap = document.createElement('span')
     linkWrap.className = `${options.blockClassName}__link-wrap`
-    linkWrap.innerHTML = linkTmpl(idx)
+    linkWrap.innerHTML = linkTmpl()
 
     if (isInlineLink) {
       handleInlineStyles(element[idx], linkWrap)
@@ -177,9 +177,9 @@ function ReadSmore(element, options) {
    * @param {Number} idx
    * @returns {String} - html string
    */
-  function linkTmpl(idx) {
+  function linkTmpl() {
     return `
-      <${options.linkElement} id="${options.blockClassName}_${idx}"
+      <${options.linkElement}
         class="${options.blockClassName}__link"
         style="cursor:pointer"
         aria-expanded="false"
@@ -196,7 +196,7 @@ function ReadSmore(element, options) {
    * @param {Bool} isInlineLink - if link element is inline with content
    */
   function setupToggleEvents(idx, isInlineLink) {
-    const link = document.querySelector(`#${options.blockClassName}_${idx}`)
+    const link = element[idx].nextSibling.firstElementChild
     link.addEventListener('click', (event) =>
       handleToggle(event, idx, isInlineLink)
     )


### PR DESCRIPTION
Hello,

Thanks for the lib :+1: 
I'm using it and a website which is not static. I notice that calling `ReadSmore(el).init()` two time in a page create duplicate link id which break the attachment of the event listener.

I replaced the logic that rely on an id  by using the internal state and nextSibling.