### PR TITLE
Feature data link text

### DIFF
--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -439,14 +439,14 @@ ReadSmore(readMores, options).init()</code>
               </article>
 
               <article class="post">
-                <span class="post__meta">100 chars, data att text</span>
+                <span class="post__meta">100 chars, data attribute more/less text</span>
                 <h2 class="post__title">We choose to go to the moon</h2>
 
                 <div 
                   class="post__content js-read-smore is-chars-100" 
                   data-read-smore-chars="100"
-                  data-read-smore-more-text="Read Schmore"
-                  data-read-smore-less-text="Read Schless">
+                  data-read-smore-more-text="Learn Schmore"
+                  data-read-smore-less-text="Learn Schless">
                   <p>We choose to go to the moon. We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard.</p> 
                   <p>Because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
                   <p>It is for these reasons that I regard the decision last year to shift our efforts in space from low to high gear as among the most important decisions that will be made during my incumbency in the office of the Presidency.</p>        

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -389,6 +389,8 @@ ReadSmore(readMores, options).init()</code>
                 <span class="sr-only">Examples Section</span>
               </a>
             </header>
+
+            
               <article class="post">
                 <span class="post__meta">30 words</span>
                 <h2 class="post__title">We choose to go to the moon</h2>
@@ -429,6 +431,22 @@ ReadSmore(readMores, options).init()</code>
                 <div 
                   class="post__content js-read-smore is-chars-100" 
                   data-read-smore-chars="100">
+                  <p>We choose to go to the moon. We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard.</p> 
+                  <p>Because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
+                  <p>It is for these reasons that I regard the decision last year to shift our efforts in space from low to high gear as among the most important decisions that will be made during my incumbency in the office of the Presidency.</p>        
+                  <p>In the last 24 hours we have seen facilities now being created for the greatest and most complex exploration in man's history. </p>
+                </div>
+              </article>
+
+              <article class="post">
+                <span class="post__meta">100 chars, data att text</span>
+                <h2 class="post__title">We choose to go to the moon</h2>
+
+                <div 
+                  class="post__content js-read-smore is-chars-100" 
+                  data-read-smore-chars="100"
+                  data-read-smore-more-text="Read Schmore"
+                  data-read-smore-less-text="Read Schless">
                   <p>We choose to go to the moon. We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard.</p> 
                   <p>Because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
                   <p>It is for these reasons that I regard the decision last year to shift our efforts in space from low to high gear as among the most important decisions that will be made during my incumbency in the office of the Presidency.</p>        

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ A customizable, lightweight vanilla JS plugin for truncating content with a Read
 - Define max word or characters via data attribute or option
 - Adds ellipse after truncated content.
 - Preserves existing markup (nice).
-- Read more / Read less text is customizable.
+- Read more / Read less text is customizable, via option or data-attribute.
 - Block level class name is customizable.
 - Read More link can be inlined with truncated content, or as block level element below.
 - No CSS deps, lib is 100% js.
@@ -100,15 +100,15 @@ ReadSmore(readMoreEls).init()
 
 `ReadSmore()` accepts a single options param, which supports the following properties:
 
-| Option         | Type    | Description                                     | Default      |
-| -------------- | ------- | ----------------------------------------------- | ------------ |
-| blockClassName | String  | BEM style block name for injected link template | `read-smore` |
-| lessText       | String  | 'Read Less' closer link text                    | `Read more`  |
-| moreText       | String  | 'Read More' expander link text                  | `Read less`  |
-| wordsCount     | Number  | Default max words (if no data attribute)        | `30`         |
-| charsCount     | Number  | Default max characters (if no data attribute)   | `null`       |
-| isInline       | Boolean | Styles link text inline with content            | `false`      |
-| linkElement    | String  | Change expander element                         | `a`          |
+| Option         | Type    | Description                                           | Default      |
+| -------------- | ------- | ----------------------------------------------------- | ------------ |
+| blockClassName | String  | BEM style block name for injected link template       | `read-smore` |
+| lessText       | String  | 'Read Less' closer link text (if no data attribute)   | `Read more`  |
+| moreText       | String  | 'Read More' expander link text (if no data attribute) | `Read less`  |
+| wordsCount     | Number  | Default max words (if no data attribute)              | `30`         |
+| charsCount     | Number  | Default max characters (if no data attribute)         | `null`       |
+| isInline       | Boolean | Styles link text inline with content                  | `false`      |
+| linkElement    | String  | Change expander element                               | `a`          |
 
 <br>
 
@@ -177,6 +177,23 @@ To truncate content by max **character** count, use the data attribute `data-rea
 <div
   class="js-read-smore"
   data-read-smore-chars="150"
+>
+  <p>Stuff and words and stuff and words.</p>
+  <p>Words and stuff and words and stuff.</p>
+  <!-- more HTML content -->
+</div>
+```
+
+#### Example defining read more/less text via data attribute
+
+To truncate content by max **character** count, use the data attribute `data-read-smore-chars=""` with desired value.
+
+```
+<div
+  class="js-read-smore"
+  data-read-smore-chars="150"
+  data-read-smore-more-text="Read Schmore"
+  data-read-smore-less-text="Read Schless"
 >
   <p>Stuff and words and stuff and words.</p>
   <p>Words and stuff and words and stuff.</p>

--- a/src/read-smore.js
+++ b/src/read-smore.js
@@ -163,7 +163,7 @@ function ReadSmore(element, options) {
     const isInlineLink = isInline(element[idx])
     const linkWrap = document.createElement('span')
     linkWrap.className = `${options.blockClassName}__link-wrap`
-    linkWrap.innerHTML = linkTmpl()
+    linkWrap.innerHTML = linkTmpl(element[idx])
 
     if (isInlineLink) {
       handleInlineStyles(element[idx], linkWrap)
@@ -177,14 +177,16 @@ function ReadSmore(element, options) {
    * @param {Number} idx
    * @returns {String} - html string
    */
-  function linkTmpl() {
+  function linkTmpl(el) {
+    const moreTextData = el.dataset.readSmoreMoreText
+    const moreText = moreTextData || options.moreText
     return `
       <${options.linkElement}
         class="${options.blockClassName}__link"
         style="cursor:pointer"
         aria-expanded="false"
         tabIndex="0">
-          ${options.moreText}
+          ${moreText}
       </${options.linkElement}>
     `
   }
@@ -201,7 +203,8 @@ function ReadSmore(element, options) {
       handleToggle(event, idx, isInlineLink)
     )
     link.addEventListener('keyup', (event) => {
-      if (event.keyCode === 13 && options.linkElement === 'a') handleToggle(event, idx, isInlineLink)
+      if (event.keyCode === 13 && options.linkElement === 'a')
+        handleToggle(event, idx, isInlineLink)
     })
   }
 
@@ -213,17 +216,20 @@ function ReadSmore(element, options) {
    * @param {Bool} isInlineLink - if link element is inline with content
    */
   function handleToggle(e, idx, isInlineLink) {
+    const moreTextData = element[idx].dataset.readSmoreMoreText
+    const lessTextData = element[idx].dataset.readSmoreLessText
+
     element[idx].classList.toggle('is-expanded')
     const target = e.currentTarget
     if (target.dataset.clicked !== 'true') {
       element[idx].innerHTML = settings.originalContentArr[idx]
-      target.innerHTML = options.lessText
+      target.innerHTML = lessTextData || options.lessText
       target.dataset.clicked = true
       target.ariaExpanded = true
       if (isInlineLink) handleInlineStyles(element[idx])
     } else {
       element[idx].innerHTML = settings.truncatedContentArr[idx]
-      target.innerHTML = options.moreText
+      target.innerHTML = moreTextData || options.moreText
       target.dataset.clicked = false
       target.ariaExpanded = false
       if (isInlineLink) handleInlineStyles(element[idx])


### PR DESCRIPTION
## Features

- Adds support for setting link more / less text via data attribute, based on request from #34 
- `data-read-smore-more-text` sets Read More text.
- `data-read-smore-less-text` sets Read Less text.
- Uses `option.moreText` | `option.lessText` unless `data-read-smore-more-text` | `data-read-smore-less-text` are set, falls back to Read More | Read Less.
- Provided demo example and updated ReadMe docs.

<br/>

**Demo with `data-read-smore-more-text`**
<img width="890" alt="Screenshot 2023-10-22 at 5 53 27 AM" src="https://github.com/stephenscaff/read-smore/assets/4933525/04089b92-ea31-4c2a-b7e8-2b778d56ed62">

**Demo with `data-read-smore-less-text`**
<img width="914" alt="Screenshot 2023-10-22 at 5 53 54 AM" src="https://github.com/stephenscaff/read-smore/assets/4933525/c95c27e8-a144-4cb3-ba90-7c831600adad">


