### PR TITLE
Refactor `removeTags` to use `DOMParser`, return `textContent`

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -38,5 +38,6 @@ export function removeTags(str) {
     return false
   }
 
-  return str.replace(/<[^>]+>/g, '')
+  const documentFragment = new DOMParser().parseFromString(str, "text/html")
+  return documentFragment.body.textContent
 }


### PR DESCRIPTION
* Rather than `gsub`ing to try to remove tags, we can rely on the browser's `DOMParser` to build a `DocumentFragment` with the given string, then return the body's `textContent` as the version of the string with its tags removed
	* See: https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
	* See: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent